### PR TITLE
Fix: Correct adjacent sibling selector syntax in ppsi1/w02/index.html ...

### DIFF
--- a/lectures/ppsi1/w02/index.html
+++ b/lectures/ppsi1/w02/index.html
@@ -342,7 +342,7 @@
               <code><span class="text-4xl">selektor + selector { <span class="opacity-15">...</span> }</span></code>
             </div>
             <div class="mt-6 text-lg w-1/2 mx-auto">
-              Następny: <code>div.p {}</code> nada styl wszystkim węzłom typu <code>p</code>, które jako pierwsze występują po <code>div</code>.
+              Następny: <code>div + p {}</code> nada styl wszystkim węzłom typu <code>p</code>, które jako pierwsze występują po <code>div</code>.
             </div>
             <div class="mt-12 text-lg w-full mx-auto">
               <code><span class="text-4xl">selector, selektor { <span class="opacity-15">...</span> }</span></code>


### PR DESCRIPTION
… (chapter 2, slide 6)

According to the presented lecture material, I'm committing a small but necessary correction to maintain the accuracy of the adjacent sibling selector (+) usage example, as specifically mentioned by the lecturer during the presentation.

![image](https://github.com/user-attachments/assets/c5f0a470-22d6-4cca-a68e-7630e6dd1b56)
